### PR TITLE
V1.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ by adding `si` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:si, "~> 1.5"}
+    {:si, "~> 1.5.1"}
   ]
 end
 ```

--- a/lib/si/unit.ex
+++ b/lib/si/unit.ex
@@ -171,7 +171,7 @@ defmodule SI.Unit do
 
 
   @spec derivative_symbol(atom(), atom()) :: atom()
-  defp derivative_symbol(original_module, multiplier_module), do: :"#{multiplier_module.symbol()}#{original_module.symbol()}"
+  defp derivative_symbol(original_module, multiplier_module), do: "#{multiplier_module.symbol()}#{original_module.symbol()}"
 
   @spec derivative_name(atom(), atom()) :: binary()
   defp derivative_name(original_module, multiplier_module), do: "#{multiplier_module.name()}#{original_module.name()}"

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule SI.MixProject do
     [
       app: :si,
       name: "SI",
-      version: "1.5.0",
+      version: "1.5.1",
       elixir: "~> 1.8",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
Change the `symbol` attribute type in the modules of derivative units. New type is `string` instead of `atom`